### PR TITLE
Removing the *.lock files condition from gititnore file.

### DIFF
--- a/templates/generapp_gitignore
+++ b/templates/generapp_gitignore
@@ -26,7 +26,6 @@ doc/*
 *~
 *.swp
 *.DS_Store
-*.lock
 backup*.dump
 *.dump
 *.orig


### PR DESCRIPTION
I think this should be removed, as it prevents storing the Gemfile.lock 
file to the repo. In heroku you can not push an app if this file is missing.

``` bash
remote:
remote: -----> Ruby app detected
remote: -----> Compiling Ruby/NoLockfile
remote:  !
remote:  !     Gemfile.lock required. Please check it in.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote:
remote:  !     Push failed
```
